### PR TITLE
Make the devshell to work with Plover source code.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,12 @@
             curl
             ipython
             jq
+            virtualenv
+            tox
+            pyqt5
           ];
+          # nativeBuildInputs = with pkgs; [ qt5.qttools.dev python3Packages.autopep8 python3Packages.flake8 ];
+          QT_QPA_PLATFORM_PLUGIN_PATH= with pkgs; "${qt5.qtbase.bin}/lib/qt-${qt5.qtbase.version}/plugins";
         };
         packages.plover = pkgs.python3Packages.callPackage ./plover.nix { inherit sources; };
         packages.default = self.packages.${system}.plover;


### PR DESCRIPTION
Add the bare minimum to make the devshell to run Plover from the source code.

`QT_QPA_PLATFORM_PLUGIN_PATH` environment variable is to work around an issue with an QT "xcb" issue I met. Plover couldn't start because of this error:

```
2023-01-12 02:07:09,034 [MainThread] WARNING: Qt: Could not find the Qt platform plugin "xcb" in ""
2023-01-12 02:07:09,034 [MainThread] ERROR: Qt: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

We still need to change the tox.ini file to pass the `PYTHONPATH` and `QT_QPA_PLATFORM_PLUGIN_PATH` environment variables into the tox environment. `PYTHONPATH` to use the Python packages in the Nix environment. `QT_QPA_PLATFORM_PLUGIN_PATH` to work around the QT xcb plugin issue. Here is a diff to do it.

```
diff --git a/tox.ini b/tox.ini
index b608544..35a790c 100644
--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ install_command = {[helpers]install_command} {packages}
 list_dependencies_command = {envpython} -m pip freeze --all
 allowlist_externals = bash
 passenv =
-       MACOSX_DEPLOYMENT_TARGET
+       MACOSX_DEPLOYMENT_TARGET PYTHONPATH
 setenv =
        SSL_CERT_FILE={envsitepackagesdir}/certifi/cacert.pem
 usedevelop = true
@@ -87,6 +87,7 @@ passenv =
        {[testenv]passenv}
        DISPLAY
        XDG_RUNTIME_DIR
+       QT_QPA_PLATFORM_PLUGIN_PATH
 commands =
        {envpython} setup.py launch -- {posargs}
```

I tested it on NixOS unstable. Steps to use the devshell:
```
plover-plugin-flake > nix develop

plover-plugin-flake > cd ../plover

plover > git apply tox.diff # add the environment variables.

plover > tox -e launch -- -l debug
```