### PR TITLE
Make lapwing-aio work

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -16,4 +16,13 @@ self: super: {
   plover_dict_commands = super.plover_dict_commands.overrideAttrs (old: {
     propagatedBuildInputs = [ setuptools-scm ];
   });
+  plover_lapwing_aio = super.plover_lapwing_aio.overrideAttrs (old: {
+    propagatedBuildInputs = [
+      self.plover_stitching
+      self.plover_python_dictionary
+      self.plover-modal-dictionary
+      self.plover_last_translation
+      self.plover_dict_commands
+    ];
+  });
 }


### PR DESCRIPTION
This is a set of overrides that make lapwing-aio work. It's mostly dependent on other plugins. I think what I've got isn't awful. It works, at least.