### PR TITLE
update plugins.nix to use the actual plugin names

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,17 @@
 Add this flake to your flake inputs, e.g. `inputs.plover-flake.url = "github:dnaq/plover-flake";`
 
 Then a plover derivation containing the plugins you want can be built with
-```
+```nix
   plover-flake.${system}.plover.with-plugins (ps: with ps; [
-    plover_dictionary_commands
-    plover_console_ui
+      plover-dict-commands
+      plover-console-ui
   ];
 ```
 where `ps` is an attribute set containing all plugins from the plugin registry
 as well as some extra plugins.
+
+> [!NOTE]
+> The plugin names were recently changed to be the same as in the [plugins registry](https://github.com/openstenoproject/plover_plugins_registry). This means that they will now consistently use dashes `-` in the names.
 
 ## Troubleshooting
 

--- a/extra-plugins.nix
+++ b/extra-plugins.nix
@@ -1,6 +1,5 @@
 {
   sources,
-  lib,
   plover,
   hid,
   bitarray,
@@ -34,18 +33,12 @@
     propagatedBuildInputs = [tomli websocket-client];
   };
 in {
-  plover_machine_hid = buildPythonPackage rec {
+  plover-machine-hid = buildPythonPackage rec {
     pname = "plover-machine-hid";
     version = "master";
     src = sources.plover-machine-hid;
     buildInputs = [plover];
     propagatedBuildInputs = [hid bitarray];
-  };
-  plover_auto_reconnect_machine = buildPythonPackage rec {
-    pname = "plover_auto_reconnect_machine";
-    version = "master";
-    src = sources.plover_auto_reconnect_machine;
-    buildInputs = [plover];
   };
   plover2cat = buildPythonPackage rec {
     pname = "plover2cat";

--- a/flake.lock
+++ b/flake.lock
@@ -98,22 +98,6 @@
         "type": "github"
       }
     },
-    "plover_auto_reconnect_machine": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696968927,
-        "narHash": "sha256-x7s0JnZE8VYXH76KaR50qoQg29GnQ405l1/72HA6AMk=",
-        "owner": "tschulte",
-        "repo": "plover_auto_reconnect_machine",
-        "rev": "aaacf26b245c82d9818ea8e4cfa62167a56d93a9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tschulte",
-        "repo": "plover_auto_reconnect_machine",
-        "type": "github"
-      }
-    },
     "plover_plugins_registry": {
       "flake": false,
       "locked": {
@@ -138,7 +122,6 @@
         "plover-machine-hid": "plover-machine-hid",
         "plover-stroke": "plover-stroke",
         "plover2cat": "plover2cat",
-        "plover_auto_reconnect_machine": "plover_auto_reconnect_machine",
         "plover_plugins_registry": "plover_plugins_registry",
         "rtf-tokenize": "rtf-tokenize"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,6 @@
     url = "github:dnaq/plover-machine-hid";
     flake = false;
   };
-  inputs.plover_auto_reconnect_machine = {
-    url = "github:tschulte/plover_auto_reconnect_machine";
-    flake = false;
-  };
   inputs.plover2cat = {
     url = "github:greenwyrt/plover2CAT";
     flake = false;

--- a/overrides.nix
+++ b/overrides.nix
@@ -1,9 +1,9 @@
-{ ruamel-yaml, prompt-toolkit, pysdl2, setuptools-scm, utils }:
+{ ruamel-yaml, prompt-toolkit, pysdl2, setuptools-scm, utils, evdev, xkbcommon }:
 self: super: {
-  plover_yaml_dictionary = super.plover_yaml_dictionary.overrideAttrs (old: {
+  plover-yaml-dictionary = super.plover-yaml-dictionary.overrideAttrs (old: {
     propagatedBuildInputs = [ ruamel-yaml ];
   });
-  plover_console_ui = super.plover_console_ui.overrideAttrs (old: {
+  plover-console-ui = super.plover-console-ui.overrideAttrs (old: {
     propagatedBuildInputs = [ prompt-toolkit ];
     doCheck = false;
     doInstallCheck = false;
@@ -13,16 +13,19 @@ self: super: {
     doCheck = false;
     doInstallCheck = false;
   });
-  plover_dict_commands = super.plover_dict_commands.overrideAttrs (old: {
+  plover-dict-commands = super.plover-dict-commands.overrideAttrs (old: {
     propagatedBuildInputs = [ setuptools-scm ];
   });
-  plover_lapwing_aio = super.plover_lapwing_aio.overrideAttrs (old: {
+  plover-uinput = super.plover-uinput.overrideAttrs (old: {
+    propagatedBuildInputs = [ evdev xkbcommon ];
+  });
+  plover-lapwing-aio = super.plover-lapwing-aio.overrideAttrs (old: {
     propagatedBuildInputs = [
-      self.plover_stitching
-      self.plover_python_dictionary
+      self.plover-stitching
+      self.plover-python-dictionary
       self.plover-modal-dictionary
-      self.plover_last_translation
-      self.plover_dict_commands
+      self.plover-last-translation
+      self.plover-dict-commands
     ];
   });
 }

--- a/overrides.nix
+++ b/overrides.nix
@@ -1,23 +1,31 @@
-{ ruamel-yaml, prompt-toolkit, pysdl2, setuptools-scm, utils, evdev, xkbcommon }:
-self: super: {
+{
+  lib,
+  ruamel-yaml,
+  prompt-toolkit,
+  pysdl2,
+  setuptools-scm,
+  utils,
+  evdev,
+  xkbcommon,
+}: self: super: {
   plover-yaml-dictionary = super.plover-yaml-dictionary.overrideAttrs (old: {
-    propagatedBuildInputs = [ ruamel-yaml ];
+    propagatedBuildInputs = [ruamel-yaml];
   });
   plover-console-ui = super.plover-console-ui.overrideAttrs (old: {
-    propagatedBuildInputs = [ prompt-toolkit ];
+    propagatedBuildInputs = [prompt-toolkit];
     doCheck = false;
     doInstallCheck = false;
   });
   plover-controller = super.plover-controller.overrideAttrs (old: {
-    propagatedBuildInputs = [ pysdl2 ];
+    propagatedBuildInputs = [pysdl2];
     doCheck = false;
     doInstallCheck = false;
   });
   plover-dict-commands = super.plover-dict-commands.overrideAttrs (old: {
-    propagatedBuildInputs = [ setuptools-scm ];
+    propagatedBuildInputs = [setuptools-scm];
   });
   plover-uinput = super.plover-uinput.overrideAttrs (old: {
-    propagatedBuildInputs = [ evdev xkbcommon ];
+    propagatedBuildInputs = [evdev xkbcommon];
   });
   plover-lapwing-aio = super.plover-lapwing-aio.overrideAttrs (old: {
     propagatedBuildInputs = [

--- a/plugins.nix
+++ b/plugins.nix
@@ -7,6 +7,7 @@
   sources,
 }: let
   inherit (lib) extends;
+  getName = plugin: lib.lists.head (builtins.split "-[0-9]" plugin.filename);
   plugins = builtins.fromJSON (builtins.readFile ./plugins.json);
   makePloverPlugin = plugin: (buildPythonPackage rec {
     pname = plugin.name;
@@ -18,11 +19,20 @@
     };
     buildInputs = [plover];
   });
+  makeRenamedPloverPlugin = plugin: let
+    name = getName plugin;
+  in {
+    inherit name;
+    value = throw "The plugin ${name} has been renamed to ${plugin.name}. See the readme for more info.";
+  };
   pluginToAttr = p: {
     name = p.pname;
     value = p;
   };
-  basicPlugins = final: prev: builtins.listToAttrs (map (p: pluginToAttr (makePloverPlugin p)) plugins);
+  basicPlugins = final: prev:
+    builtins.listToAttrs (map (p: makeRenamedPloverPlugin p) plugins)
+    # Concat the sets and make sure the correct names have priority over the renamed ones
+    // builtins.listToAttrs (map (p: pluginToAttr (makePloverPlugin p)) plugins);
   overrides = callPackage ./overrides.nix {};
 
   initialPackages = self: callPackage ./extra-plugins.nix {inherit plover sources;};

--- a/plugins.nix
+++ b/plugins.nix
@@ -9,10 +9,11 @@
   inherit (lib) extends;
   plugins = builtins.fromJSON (builtins.readFile ./plugins.json);
   makePloverPlugin = plugin: (buildPythonPackage rec {
-    pname = lib.lists.head (builtins.split "-[0-9]" plugin.filename);
+    pname = plugin.name;
     version = plugin.version;
     src = fetchPypi {
-      inherit pname version;
+      inherit version;
+      pname = lib.lists.head (builtins.split "-[0-9]" plugin.filename);
       sha256 = plugin.sha256;
     };
     buildInputs = [plover];


### PR DESCRIPTION
This should break the configs of most people, but i think the change will be better to ensure consistency with regular plover, and have a consistent naming scheme between plugins.

I've also added the required dependencies to `plover-uinput` in `overrides.nix`, formatted with alejandra and removed `auto-reconnect-machine`, as it's now in the plugins registry.