### PR TITLE
make plover-emoji work

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -7,7 +7,21 @@
   utils,
   evdev,
   xkbcommon,
-}: self: super: {
+  buildPythonPackage,
+  fetchPypi
+}: self: super:
+let
+  simplefuzzyset = buildPythonPackage rec {
+    pname = "simplefuzzyset";
+    version = "0.0.12";
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-mhsww4tq+3bGYAvdZsHB3D2FBbCC6ePUZvYPQOi34fI=";
+    };
+  };
+in
+{
   plover-yaml-dictionary = super.plover-yaml-dictionary.overrideAttrs (old: {
     propagatedBuildInputs = [ruamel-yaml];
   });
@@ -34,6 +48,11 @@
       self.plover-modal-dictionary
       self.plover-last-translation
       self.plover-dict-commands
+    ];
+  });
+  plover-emoji = super.plover-emoji.overrideAttrs (old: {
+    propagatedBuildInputs = [
+      simplefuzzyset
     ];
   });
 }


### PR DESCRIPTION
needs the dependency 'simplefuzzyset' from pypi, which is not in nixpkgs, so I'm making it in a let expression. 

I'm not really sure if that's a sensible thing to do, but hey, it works. Look: 😀.