### PR TITLE
tmp pin nixpkgs, fixes run on wayland

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Temporarily pinned nixpkgs
+    nixpkgs.url = "github:NixOS/nixpkgs/2631b0b7abcea6e640ce31cd78ea58910d31e650";
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     plover = {
       url = "github:openstenoproject/plover";

--- a/plover.nix
+++ b/plover.nix
@@ -42,6 +42,7 @@ buildPythonPackage {
 
   buildInputs = [
     qt6.qtsvg # required for rendering icons
+    qt6.qtwayland
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Rolls back 5e81c3b7900812f729a150b755cf19363278c62d and pin nixpkgs

also adds `qtwayland` as a `buildInput` of plover.

Should fix the following runtime error:

```
2025-04-21 13:06:22,705 [MainThread] ERROR: connection to existing instance failed, force cleaning before restart

2025-04-21 13:06:23,315 [MainThread] WARNING: Qt: Could not find the Qt platform plugin "wayland" in ""
2025-04-21 13:06:23,315 [MainThread] ERROR: Qt: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: offscreen, minimal, minimalegl, linuxfb, vnc, xcb, vkkhrdisplay, eglfs.

[1]    25207 IOT instruction (core dumped)  plover
```