### PR TITLE
overrides: add dependencies for `plover-stenobee`

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -6,6 +6,7 @@
   evdev,
   xkbcommon,
   lxml,
+  inflect,
   buildPythonPackage,
   fetchPypi,
 }:
@@ -34,6 +35,12 @@ final: prev: {
   });
   plover-svg-layout-display = prev.plover-svg-layout-display.overrideAttrs (old: {
     propagatedBuildInputs = [ lxml ];
+  });
+  plover-stenobee = prev.plover-stenobee.overrideAttrs (old: {
+    propagatedBuildInputs = [
+      inflect 
+      final.plover-python-dictionary
+    ];
   });
   plover-lapwing-aio = prev.plover-lapwing-aio.overrideAttrs (old: {
     propagatedBuildInputs = [


### PR DESCRIPTION
Closes #217. Feel free to reopen if not works for you.

- [x] Launch `plover` without errors about `inflect`
- [x] Load python dictionary data file without errors
- [ ] Verify `plover-stenobee` works
