### PR TITLE
CI: setup formatter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,5 @@ jobs:
       - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix fmt -- --ci
       - run: nix build

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,8 @@
         };
       });
 
+      formatter = forEachSystem (pkgs: pkgs.nixfmt-tree);
+
       ploverPlugins = forEachSystem (
         pkgs:
         pkgs.python3Packages.callPackage ./plugins.nix {

--- a/overrides.nix
+++ b/overrides.nix
@@ -38,7 +38,7 @@ final: prev: {
   });
   plover-stenobee = prev.plover-stenobee.overrideAttrs (old: {
     propagatedBuildInputs = [
-      inflect 
+      inflect
       final.plover-python-dictionary
     ];
   });

--- a/plover.nix
+++ b/plover.nix
@@ -19,7 +19,7 @@
   cmarkgfm,
   requests-cache,
   inputs,
-  writeShellScriptBin
+  writeShellScriptBin,
 }:
 let
   plover-stroke = buildPythonPackage {


### PR DESCRIPTION
Adds `nixfmt-tree` as `formatter` and runs it on CI.

The first CI is going to fail, because HEAD has wrong format files (including my commit, sorry!)