### PR TITLE
Unpin nixpkgs

### DIFF
--- a/extra-plugins.nix
+++ b/extra-plugins.nix
@@ -6,6 +6,7 @@
   dulwich,
   odfpy,
   pyparsing,
+  setuptools,
   tomli,
   websocket-client,
   hatchling,
@@ -41,6 +42,8 @@ in
     pname = "plover-machine-hid";
     version = "master";
     src = inputs.plover-machine-hid;
+    pyproject = true;
+    build-system = [ setuptools ];
     buildInputs = [ plover ];
     dependencies = [
       hid
@@ -51,6 +54,8 @@ in
     pname = "plover2cat";
     version = "master";
     src = inputs.plover2cat;
+    pyproject = true;
+    build-system = [ setuptools ];
     buildInputs = [ plover ];
     dependencies = [
       dulwich

--- a/extra-plugins.nix
+++ b/extra-plugins.nix
@@ -23,7 +23,6 @@ let
     doCheck = false;
   };
   obsws-python = buildPythonPackage rec {
-    format = "pyproject";
     pname = "obsws_python";
     version = "1.6.1";
     src = fetchPypi {
@@ -31,7 +30,7 @@ let
       sha256 = "sha256-n1l4M3xVfp+8pnO1rF3Ww7Vwyi6GCD3/QHLbrZOXp7w=";
     };
     buildInputs = [ hatchling ];
-    propagatedBuildInputs = [
+    dependencies = [
       tomli
       websocket-client
     ];
@@ -43,7 +42,7 @@ in
     version = "master";
     src = inputs.plover-machine-hid;
     buildInputs = [ plover ];
-    propagatedBuildInputs = [
+    dependencies = [
       hid
       bitarray
     ];
@@ -53,7 +52,7 @@ in
     version = "master";
     src = inputs.plover2cat;
     buildInputs = [ plover ];
-    propagatedBuildInputs = [
+    dependencies = [
       dulwich
       odfpy
       pyparsing

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1751792365,
+        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
             withPlugins =
               f: # f is a function such as (ps: with ps; [ plugin names ])
               plover'.overrideAttrs (old: {
-                dependencies = old.dependencies ++ (f self.ploverPlugins.${pkgs.system});
+                propagatedBuildInputs = old.propagatedBuildInputs ++ (f self.ploverPlugins.${pkgs.system});
               });
           in
           plover' // { inherit withPlugins; };

--- a/flake.nix
+++ b/flake.nix
@@ -68,8 +68,8 @@
             plover' = pkgs.python3Packages.callPackage ./plover.nix { inherit inputs; };
             withPlugins =
               f: # f is a function such as (ps: with ps; [ plugin names ])
-              plover'.overrideAttrs (old: {
-                propagatedBuildInputs = old.propagatedBuildInputs ++ (f self.ploverPlugins.${pkgs.system});
+              plover'.overridePythonAttrs (old: {
+                dependencies = old.dependencies ++ (f self.ploverPlugins.${pkgs.system});
               });
           in
           plover' // { inherit withPlugins; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,6 @@
 {
   inputs = {
-    # Temporarily pinned nixpkgs
-    nixpkgs.url = "github:NixOS/nixpkgs/2631b0b7abcea6e640ce31cd78ea58910d31e650";
-    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     plover = {
       url = "github:openstenoproject/plover";
@@ -71,12 +69,10 @@
             withPlugins =
               f: # f is a function such as (ps: with ps; [ plugin names ])
               plover'.overrideAttrs (old: {
-                propagatedBuildInputs = old.propagatedBuildInputs ++ (f self.ploverPlugins.${pkgs.system});
+                dependencies = old.dependencies ++ (f self.ploverPlugins.${pkgs.system});
               });
-
-            with-plugins = _: throw "The `with-plugins` option has been renamed to `withPlugins`.";
           in
-          plover' // { inherit withPlugins with-plugins; };
+          plover' // { inherit withPlugins; };
 
         update = pkgs.callPackage ./update.nix { inherit inputs; };
       });

--- a/overrides.nix
+++ b/overrides.nix
@@ -50,6 +50,10 @@ final: prev: {
       final.plover-last-translation
       final.plover-dict-commands
     ];
+    # NOTE: Remove it on failure:
+    postPatch = ''
+      substituteInPlace "setup.cfg" --replace-fail "setuptools<77" "setuptools"
+    '';
   });
   plover-emoji =
     let

--- a/overrides.nix
+++ b/overrides.nix
@@ -2,6 +2,7 @@
   ruamel-yaml,
   prompt-toolkit,
   pysdl2,
+  setuptools,
   setuptools-scm,
   evdev,
   xkbcommon,
@@ -11,39 +12,39 @@
   fetchPypi,
 }:
 final: prev: {
-  plover-yaml-dictionary = prev.plover-yaml-dictionary.overrideAttrs (old: {
-    propagatedBuildInputs = [ ruamel-yaml ];
+  plover-yaml-dictionary = prev.plover-yaml-dictionary.overridePythonAttrs (old: {
+    dependencies = [ ruamel-yaml ];
   });
-  plover-console-ui = prev.plover-console-ui.overrideAttrs (old: {
-    propagatedBuildInputs = [ prompt-toolkit ];
+  plover-console-ui = prev.plover-console-ui.overridePythonAttrs (old: {
+    dependencies = [ prompt-toolkit ];
     doCheck = false;
     doInstallCheck = false;
   });
-  plover-controller = prev.plover-controller.overrideAttrs (old: {
-    propagatedBuildInputs = [ pysdl2 ];
+  plover-controller = prev.plover-controller.overridePythonAttrs (old: {
+    dependencies = [ pysdl2 ];
     doCheck = false;
     doInstallCheck = false;
   });
-  plover-dict-commands = prev.plover-dict-commands.overrideAttrs (old: {
-    propagatedBuildInputs = [ setuptools-scm ];
+  plover-dict-commands = prev.plover-dict-commands.overridePythonAttrs (old: {
+    dependencies = [ setuptools-scm ];
   });
-  plover-uinput = prev.plover-uinput.overrideAttrs (old: {
-    propagatedBuildInputs = [
+  plover-uinput = prev.plover-uinput.overridePythonAttrs (old: {
+    dependencies = [
       evdev
       xkbcommon
     ];
   });
-  plover-svg-layout-display = prev.plover-svg-layout-display.overrideAttrs (old: {
-    propagatedBuildInputs = [ lxml ];
+  plover-svg-layout-display = prev.plover-svg-layout-display.overridePythonAttrs (old: {
+    dependencies = [ lxml ];
   });
-  plover-stenobee = prev.plover-stenobee.overrideAttrs (old: {
-    propagatedBuildInputs = [
+  plover-stenobee = prev.plover-stenobee.overridePythonAttrs (old: {
+    dependencies = [
       inflect
       final.plover-python-dictionary
     ];
   });
-  plover-lapwing-aio = prev.plover-lapwing-aio.overrideAttrs (old: {
-    propagatedBuildInputs = [
+  plover-lapwing-aio = prev.plover-lapwing-aio.overridePythonAttrs (old: {
+    dependencies = [
       final.plover-stitching
       final.plover-python-dictionary
       final.plover-modal-dictionary
@@ -60,15 +61,16 @@ final: prev: {
       simplefuzzyset = buildPythonPackage rec {
         pname = "simplefuzzyset";
         version = "0.0.12";
-
         src = fetchPypi {
           inherit pname version;
           hash = "sha256-mhsww4tq+3bGYAvdZsHB3D2FBbCC6ePUZvYPQOi34fI=";
         };
+        pyproject = true;
+        build-system = [ setuptools ];
       };
     in
-    prev.plover-emoji.overrideAttrs (old: {
-      propagatedBuildInputs = [
+    prev.plover-emoji.overridePythonAttrs (old: {
+      dependencies = [
         simplefuzzyset
       ];
     });

--- a/overrides.nix
+++ b/overrides.nix
@@ -12,38 +12,38 @@
 }:
 final: prev: {
   plover-yaml-dictionary = prev.plover-yaml-dictionary.overrideAttrs (old: {
-    dependencies = [ ruamel-yaml ];
+    propagatedBuildInputs = [ ruamel-yaml ];
   });
   plover-console-ui = prev.plover-console-ui.overrideAttrs (old: {
-    dependencies = [ prompt-toolkit ];
+    propagatedBuildInputs = [ prompt-toolkit ];
     doCheck = false;
     doInstallCheck = false;
   });
   plover-controller = prev.plover-controller.overrideAttrs (old: {
-    dependencies = [ pysdl2 ];
+    propagatedBuildInputs = [ pysdl2 ];
     doCheck = false;
     doInstallCheck = false;
   });
   plover-dict-commands = prev.plover-dict-commands.overrideAttrs (old: {
-    dependencies = [ setuptools-scm ];
+    propagatedBuildInputs = [ setuptools-scm ];
   });
   plover-uinput = prev.plover-uinput.overrideAttrs (old: {
-    dependencies = [
+    propagatedBuildInputs = [
       evdev
       xkbcommon
     ];
   });
   plover-svg-layout-display = prev.plover-svg-layout-display.overrideAttrs (old: {
-    dependencies = [ lxml ];
+    propagatedBuildInputs = [ lxml ];
   });
   plover-stenobee = prev.plover-stenobee.overrideAttrs (old: {
-    dependencies = [
+    propagatedBuildInputs = [
       inflect
       final.plover-python-dictionary
     ];
   });
   plover-lapwing-aio = prev.plover-lapwing-aio.overrideAttrs (old: {
-    dependencies = [
+    propagatedBuildInputs = [
       final.plover-stitching
       final.plover-python-dictionary
       final.plover-modal-dictionary
@@ -64,7 +64,7 @@ final: prev: {
       };
     in
     prev.plover-emoji.overrideAttrs (old: {
-      dependencies = [
+      propagatedBuildInputs = [
         simplefuzzyset
       ];
     });

--- a/overrides.nix
+++ b/overrides.nix
@@ -12,38 +12,38 @@
 }:
 final: prev: {
   plover-yaml-dictionary = prev.plover-yaml-dictionary.overrideAttrs (old: {
-    propagatedBuildInputs = [ ruamel-yaml ];
+    dependencies = [ ruamel-yaml ];
   });
   plover-console-ui = prev.plover-console-ui.overrideAttrs (old: {
-    propagatedBuildInputs = [ prompt-toolkit ];
+    dependencies = [ prompt-toolkit ];
     doCheck = false;
     doInstallCheck = false;
   });
   plover-controller = prev.plover-controller.overrideAttrs (old: {
-    propagatedBuildInputs = [ pysdl2 ];
+    dependencies = [ pysdl2 ];
     doCheck = false;
     doInstallCheck = false;
   });
   plover-dict-commands = prev.plover-dict-commands.overrideAttrs (old: {
-    propagatedBuildInputs = [ setuptools-scm ];
+    dependencies = [ setuptools-scm ];
   });
   plover-uinput = prev.plover-uinput.overrideAttrs (old: {
-    propagatedBuildInputs = [
+    dependencies = [
       evdev
       xkbcommon
     ];
   });
   plover-svg-layout-display = prev.plover-svg-layout-display.overrideAttrs (old: {
-    propagatedBuildInputs = [ lxml ];
+    dependencies = [ lxml ];
   });
   plover-stenobee = prev.plover-stenobee.overrideAttrs (old: {
-    propagatedBuildInputs = [
+    dependencies = [
       inflect
       final.plover-python-dictionary
     ];
   });
   plover-lapwing-aio = prev.plover-lapwing-aio.overrideAttrs (old: {
-    propagatedBuildInputs = [
+    dependencies = [
       final.plover-stitching
       final.plover-python-dictionary
       final.plover-modal-dictionary
@@ -64,7 +64,7 @@ final: prev: {
       };
     in
     prev.plover-emoji.overrideAttrs (old: {
-      propagatedBuildInputs = [
+      dependencies = [
         simplefuzzyset
       ];
     });

--- a/plover.nix
+++ b/plover.nix
@@ -26,11 +26,15 @@ let
     pname = "plover_stroke";
     version = "master";
     src = inputs.plover-stroke;
+    pyproject = true;
+    build-system = [ setuptools ];
   };
   rtf-tokenize = buildPythonPackage {
     pname = "rtf_tokenize";
     version = "master";
     src = inputs.rtf-tokenize;
+    pyproject = true;
+    build-system = [ setuptools ];
   };
   # Matches missing pyside6-uic and pyside6-rcc implementations
   # https://github.com/NixOS/nixpkgs/issues/277849
@@ -47,6 +51,8 @@ buildPythonPackage {
   pname = "plover";
   version = "master";
   src = inputs.plover;
+  pyproject = true;
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [
     qt6.qtbase
@@ -60,7 +66,7 @@ buildPythonPackage {
     qt6.qtwayland
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     Babel
     pyside6
     xlib
@@ -82,6 +88,11 @@ buildPythonPackage {
     rtf-tokenize
   ];
 
+  # PySide6-Essentials it not on nixpkgs. See: https://github.com/NixOS/nixpkgs/issues/277849
+  postPatch = ''
+    substituteInPlace "pyproject.toml" --replace-fail "PySide6-Essentials" "PySide6"
+  '';
+
   postInstall = ''
     mkdir -p $out/share/icons/hicolor/128x128/apps
     cp $src/plover/assets/plover.png $out/share/icons/hicolor/128x128/apps/plover.png
@@ -89,7 +100,13 @@ buildPythonPackage {
     mkdir -p $out/share/applications
     cp $src/linux/plover.desktop $out/share/applications/plover.desktop
     substituteInPlace "$out/share/applications/plover.desktop" \
-      --replace-warn "Exec=plover" "Exec=$out/bin/plover"
+      --replace-fail "Exec=plover" "Exec=$out/bin/plover"
+  '';
+
+  # See: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/qt.section.md
+  dontWrapQtApps = true;
+  preFixup = ''
+    wrapQtApp "$out/bin/plover"
   '';
 
   doCheck = false;

--- a/plover.nix
+++ b/plover.nix
@@ -115,6 +115,4 @@ buildPythonPackage {
   preFixup = ''
     wrapQtApp "$out/bin/plover"
   '';
-
-  doCheck = false;
 }

--- a/plover.nix
+++ b/plover.nix
@@ -91,6 +91,9 @@ buildPythonPackage {
   # PySide6-Essentials it not on nixpkgs. See: https://github.com/NixOS/nixpkgs/issues/277849
   postPatch = ''
     substituteInPlace "pyproject.toml" --replace-fail "PySide6-Essentials" "PySide6"
+    substituteInPlace "reqs/setup.txt" --replace-fail "PySide6-Essentials" "PySide6"
+    substituteInPlace "reqs/dist_extra_gui_qt.txt" --replace-fail "PySide6-Essentials" "PySide6"
+    substituteInPlace "reqs/constraints.txt" --replace-fail "PySide6-Essentials" "PySide6"
   '';
 
   postInstall = ''

--- a/plover.nix
+++ b/plover.nix
@@ -57,13 +57,17 @@ buildPythonPackage {
   nativeBuildInputs = [
     qt6.qtbase
     qt6.wrapQtAppsHook
-    pyside-tools-uic
-    pyside-tools-rcc
   ];
 
   buildInputs = [
     qt6.qtsvg # required for rendering icons
     qt6.qtwayland
+  ];
+
+  # Other Plover plugins can depend on `plover_build_utils/setup.py`, so:
+  propagatedNativeBuildInputs = [
+    pyside-tools-uic
+    pyside-tools-rcc
   ];
 
   dependencies = [

--- a/plover.nix
+++ b/plover.nix
@@ -92,6 +92,35 @@ buildPythonPackage {
     rtf-tokenize
   ];
 
+  pythonImportsCheck = [
+    "plover"
+    "plover.assets"
+    "plover.command"
+    "plover.dictionary"
+    "plover.gui_none"
+    "plover.gui_qt"
+    "plover.gui_qt.resources"
+    "plover.machine"
+    "plover.machine.keyboard_capture"
+    "plover.macro"
+    "plover.messages"
+    "plover.messages.es.LC_MESSAGES"
+    "plover.messages.fr.LC_MESSAGES"
+    "plover.messages.it.LC_MESSAGES"
+    "plover.messages.nl.LC_MESSAGES"
+    "plover.messages.zh_tw.LC_MESSAGES"
+    "plover.meta"
+    "plover.oslayer"
+    "plover.oslayer.linux"
+    "plover.oslayer.osx"
+    "plover.oslayer.windows"
+    "plover.output"
+    "plover.plugins_manager"
+    "plover.scripts"
+    "plover.system"
+    "plover_build_utils"
+  ];
+
   # PySide6-Essentials it not on nixpkgs. See: https://github.com/NixOS/nixpkgs/issues/277849
   postPatch = ''
     substituteInPlace "pyproject.toml" --replace-fail "PySide6-Essentials" "PySide6"

--- a/plugins.nix
+++ b/plugins.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   lib,
   plover,
+  setuptools,
   inputs,
 }:
 let
@@ -20,6 +21,8 @@ let
         inherit (plugin) sha256;
       };
       buildInputs = [ plover ];
+      pyproject = true;
+      build-system = [ setuptools ];
     });
   pluginToAttr = p: {
     name = p.pname;


### PR DESCRIPTION
Currently nixpkgs is pinned, probably for `plover_plugins_manager`. Now that Plover after [`v5.0.0.dev1 (2025-06-03)`](https://github.com/openstenoproject/plover/blob/65fc2b46425784944d50a38f447c6fa69fe54c83/NEWS.md#v500dev1-2025-06-03) is not dependent on it, we would be free to unpin nixpkgs!

## Notes

### Follow latest Python packages

According to [the manual](https://nixos.org/manual/nixpkgs/stable/#buildpythonpackage-function), today we write `dependencies` instead of `propagatedBuildInputs`.

### Show icons

I _somehow_ needed the followings in `plover.nix` to show SVG icons. See also [the nixpkgs manual on Qt](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/qt.section.md).

```nix
  dontWrapQtApps = true;
  preFixup = ''
    wrapQtApp "$out/bin/plover"
  '';
```

At the end of the manual, it says the following, so probably the above is a correct fix?:

```nix
An example of when you'd always need to do this is with Python applications that use PyQt.
```

## Progress

- [x] Tested on X
- [x] Tested on Wayland
- Not tested on macOS, since current flake is missing Darwin dependencies.
