### PR TITLE
Replace `plover-casecat-dictionary` with `plover-casecat`

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -22,6 +22,7 @@
   importlib-metadata,
   inflect,
   jsonpickle,
+  kaitaistruct,
   lxml,
   numpy,
   odfpy,
@@ -120,8 +121,9 @@ final: prev: {
     meta.broken = true;
   });
 
-  plover-casecat-dictionary = prev.plover-casecat-dictionary.overridePythonAttrs (old: {
+  plover-casecat = prev.plover-casecat.overridePythonAttrs (old: {
     nativeBuildInputs = [ setuptools-scm ];
+    dependencies = [ kaitaistruct ];
   });
 
   plover-cat = prev.plover-cat.overridePythonAttrs (old: {


### PR DESCRIPTION
Following the upstream change: https://github.com/openstenoproject/plover_plugins_registry/pull/63.

> Maybe `nix build .#plover-full` could be added to `.github/workflows/flake-update.yml`.
