### PR TITLE
Change plover config file path for Linux

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -132,7 +132,7 @@ in
           home.packages = [ cfg.package ];
         }
         (lib.mkIf (cfg.settings != null && pkgs.stdenvNoCC.isLinux) {
-          lib.xdg.configFile."plover".source = configFile;
+          home.file.".config/plover/plover.cfg".source = configFile;
         })
         (lib.mkIf (cfg.settings != null && pkgs.stdenvNoCC.isDarwin) {
           home.file."Library/Application Support/plover/plover.cfg".source = configFile;


### PR DESCRIPTION
The original didn't work on my machine. `$XDG_CONFIG_DIR` is not set on my system, so I suspect that is the issue.