### PR TITLE
Fix babel rename in nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761672384,
-        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
+        "lastModified": 1761907660,
+        "narHash": "sha256-kJ8lIZsiPOmbkJypG+B5sReDXSD1KGu2VEPNqhRa/ew=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
+        "rev": "2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15",
         "type": "github"
       },
       "original": {

--- a/overrides.nix
+++ b/overrides.nix
@@ -489,7 +489,7 @@ final: prev: {
     dependencies = [ ruamel-yaml ];
   });
 
-  spectra-lexer = prev.spectra-lexer.overridePythonAttrs (old: {
+  plover-spectra-lexer = prev.plover-spectra-lexer.overridePythonAttrs (old: {
     # >        PyQt5>=5.14
     meta.broken = true;
   });

--- a/plover.nix
+++ b/plover.nix
@@ -12,7 +12,7 @@
 
   # dependencies
   appdirs,
-  Babel,
+  babel,
   certifi,
   cmarkgfm,
   evdev,
@@ -123,7 +123,7 @@ buildPythonPackage {
   ];
 
   dependencies = [
-    Babel
+    babel
     pyside6
     xlib
     pyserial


### PR DESCRIPTION
The Babel package was renamed to babel in latest
nixpkgs, breaking the build.
