### PR TITLE
Changes needed for plover-hid builtin support

### DIFF
--- a/extra-plugins.nix
+++ b/extra-plugins.nix
@@ -7,16 +7,4 @@
   buildPythonPackage,
 }:
 {
-  plover-machine-hid = buildPythonPackage {
-    pname = "plover-machine-hid";
-    version = "master";
-    src = inputs.plover-machine-hid;
-    pyproject = true;
-    build-system = [ setuptools ];
-    buildInputs = [ plover ];
-    dependencies = [
-      hid
-      bitarray
-    ];
-  };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "plover": {
       "flake": false,
       "locked": {
-        "lastModified": 1761802279,
-        "narHash": "sha256-6oz3gUQuXsguAgeVrfzSUTVb8MSBeSH68lu/TzXjyIg=",
+        "lastModified": 1762237592,
+        "narHash": "sha256-eRzih8PWgDsNN3yGkkFEK0BlSOeAA6LU+GwRAOdwS5w=",
         "owner": "openstenoproject",
         "repo": "plover",
-        "rev": "28d5425a53b2e9ee661e930bffb3e9cbdb268508",
+        "rev": "eb2f0b641b1c2b353f3458abdb85293b81919680",
         "type": "github"
       },
       "original": {

--- a/plover.nix
+++ b/plover.nix
@@ -16,6 +16,7 @@
   certifi,
   cmarkgfm,
   evdev,
+  hid,
   psutil,
   pyside6,
   pyserial,
@@ -124,6 +125,7 @@ buildPythonPackage {
 
   dependencies = [
     babel
+    hid
     pyside6
     xlib
     pyserial


### PR DESCRIPTION
This commit adds the changes needed now that
plover hid is part of the main distribution
and no longer an external plugin.

The main changes are to add the python package
hid to the deps of plover, and to remove the
old, now unnecessary plugin.