### PR TITLE
fix: replace `pkgs.system` with `pkgs.stdenv.hostPlaform.system`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
             withPlugins =
               f: # f is a function such as (ps: with ps; [ plugin names ])
               plover'.overridePythonAttrs (old: {
-                dependencies = old.dependencies ++ (f self.ploverPlugins.${pkgs.system});
+                dependencies = old.dependencies ++ (f self.ploverPlugins.${pkgs.stdenv.hostPlatform.system});
               });
           in
           plover' // { inherit withPlugins; };
@@ -86,7 +86,7 @@
             withPlugins =
               f: # f is a function such as (ps: with ps; [ plugin names ])
               plover'.overridePythonAttrs (old: {
-                dependencies = old.dependencies ++ (f self.ploverPlugins.${pkgs.system});
+                dependencies = old.dependencies ++ (f self.ploverPlugins.${pkgs.stdenv.hostPlatform.system});
               });
           in
           plover' // { inherit withPlugins; };

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -24,11 +24,11 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = self.packages.${pkgs.system}.plover;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.plover;
       example =
         lib.literalExpression # nix
           ''
-            inputs.plover-flake.${pkgs.system}.plover.withPlugins (ps: with ps; [
+            inputs.plover-flake.${pkgs.stdenv.hostPlatform.system}.plover.withPlugins (ps: with ps; [
               plover-lapwing-aio
               plover-console-ui
             ])

--- a/readme.md
+++ b/readme.md
@@ -40,14 +40,14 @@ If you use [home-manager](https://github.com/nix-community/home-manager), there 
 
   programs.plover = {
     enable = true;
-    package = inputs.plover-flake.packages.${pkgs.system}.plover.withPlugins (
+    package = inputs.plover-flake.packages.${pkgs.stdenv.hostPlatform.system}.plover.withPlugins (
       ps: with ps; [
         plover-lapwing-aio
       ]
     );
 
     # Or, use `plover-full` if you want Plover with all the plugins installed:
-    # package = inputs.plover-flake.packages.${pkgs.system}.plover-full;
+    # package = inputs.plover-flake.packages.${pkgs.stdenv.hostPlatform.system}.plover-full;
 
     settings = {
       "Machine Configuration" = {


### PR DESCRIPTION
Sources:

- https://www.github.com/snowfallorg/lib/issues/140
- [How to fix `evaluation warning: ‘system’ has been renamed to/replaced by ‘stdenv.hostPlatform.system’`](https://discourse.nixos.org/t/how-to-fix-evaluation-warning-system-has-been-renamed-to-replaced-by-stdenv-hostplatform-system/72120)
