### PR TITLE
fix: delete unused inputs (`plover-machine-hid` and `pyobjc`)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,23 +80,6 @@
         "type": "github"
       }
     },
-    "pyobjc": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1736669867,
-        "narHash": "sha256-Kj1CH1+RYTFszao9G7P3fnsgBjTcvsq4ZpxdjHzQ520=",
-        "owner": "ronaldoussoren",
-        "repo": "pyobjc",
-        "rev": "e29d3a0c80b5bb852e4311ce10827efab9844c6c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ronaldoussoren",
-        "ref": "v11.0",
-        "repo": "pyobjc",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
@@ -104,7 +87,6 @@
         "plover-stroke": "plover-stroke",
         "plover2cat": "plover2cat",
         "plover_plugins_registry": "plover_plugins_registry",
-        "pyobjc": "pyobjc",
         "rtf-tokenize": "rtf-tokenize"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -32,22 +32,6 @@
         "type": "github"
       }
     },
-    "plover-machine-hid": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1757266704,
-        "narHash": "sha256-S+NBVnLjWdINTRpNIZvGotNGiMVSnvq1NZRPnKCmZyM=",
-        "owner": "dnaq",
-        "repo": "plover-machine-hid",
-        "rev": "db917f8b2545964fdaa2f664d1d1e2afafae96a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dnaq",
-        "repo": "plover-machine-hid",
-        "type": "github"
-      }
-    },
     "plover-stroke": {
       "flake": false,
       "locked": {
@@ -117,7 +101,6 @@
       "inputs": {
         "nixpkgs": "nixpkgs",
         "plover": "plover",
-        "plover-machine-hid": "plover-machine-hid",
         "plover-stroke": "plover-stroke",
         "plover2cat": "plover2cat",
         "plover_plugins_registry": "plover_plugins_registry",

--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,6 @@
       url = "github:openstenoproject/plover_stroke";
       flake = false;
     };
-    plover-machine-hid = {
-      url = "github:dnaq/plover-machine-hid";
-      flake = false;
-    };
     plover2cat = {
       url = "github:greenwyrt/plover2CAT";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -22,10 +22,6 @@
       url = "github:greenwyrt/plover2CAT";
       flake = false;
     };
-    pyobjc = {
-      url = "github:ronaldoussoren/pyobjc/v11.0";
-      flake = false;
-    };
   };
 
   outputs =


### PR DESCRIPTION
Just delete unused inputs:

- `plover-machine-hid`: not in use (somehow)
- `pyobjc`: not in use, because now `pyobjc-*` is in nixpkgs
