### PR TITLE
fix: mark `plover2cat` as non-broken

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     "plover2cat": {
       "flake": false,
       "locked": {
-        "lastModified": 1757574932,
-        "narHash": "sha256-kIDuIezGN+n3RDWMOlR6eFlQlQDp6okKgQCk71AgUDs=",
+        "lastModified": 1769293912,
+        "narHash": "sha256-nxyNTYZ/8VqxPa2d2pHeaTRae1J4zu5h29lDGzA/C/U=",
         "owner": "greenwyrt",
         "repo": "plover2CAT",
-        "rev": "477163958b1a9e6fc48337be137173570fa7350a",
+        "rev": "f6c788c5e343ada345a787579b5561c7255d4277",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     "plover_plugins_registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1766765190,
-        "narHash": "sha256-hLdwfT1YrNWvVWrwm3yAhxcxgZvKK6QOyFjj47QquVs=",
+        "lastModified": 1769296318,
+        "narHash": "sha256-xpDpYhxzqxMV5wTZ4MC/L5V6DodQG4aSjheLcJIXHjA=",
         "owner": "openstenoproject",
         "repo": "plover_plugins_registry",
-        "rev": "741564491936e2bca179094f8c19f18627c89186",
+        "rev": "627f6f4650cd75a62f6741f8643bd437e75c9eeb",
         "type": "github"
       },
       "original": {

--- a/overrides.nix
+++ b/overrides.nix
@@ -100,9 +100,10 @@ final: prev: {
       spylls
       obsws-python
     ];
-
-    # AttributeError: module 'plover_build_utils.pyqt' has no attribute 'fix_icons'
-    meta.broken = true;
+    postPatch = ''
+      substituteInPlace "setup.cfg" --replace-fail "PySide6-Essentials" "PySide6"
+      sed -i '/PySide6-Addons/d' 'setup.cfg'
+    '';
   };
 
   plover-1password = prev.plover-1password.overridePythonAttrs (old: {


### PR DESCRIPTION
This is a PR for tracking the upstream change:

- https://github.com/opensteno/plover_plugins_registry/pull/66

Because `PySide6-Essentials` is not in nixpkgs, I replaced it.
