### PR TITLE
Change hid dependency to hidapi

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769170682,
-        "narHash": "sha256-oMmN1lVQU0F0W2k6OI3bgdzp2YOHWYUAw79qzDSjenU=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5296fdd05cfa2c187990dd909864da9658df755",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "plover": {
       "flake": false,
       "locked": {
-        "lastModified": 1769110446,
-        "narHash": "sha256-XMfBtyDMvcvmgBlOktP5mSX0BfpILHo2WB6pdNPQ6Is=",
+        "lastModified": 1769494862,
+        "narHash": "sha256-vHsGisi53KFYzbE+GFtF1kQWShqlUxnL4791v4Amsqw=",
         "owner": "openstenoproject",
         "repo": "plover",
-        "rev": "84616762f11c3ab37bdda0d88783fa98c33f5aef",
+        "rev": "78064997b471cd9a02308f5a7bb524e19eb1e522",
         "type": "github"
       },
       "original": {

--- a/overrides.nix
+++ b/overrides.nix
@@ -399,11 +399,8 @@ final: prev: {
   });
 
   plover-stenohid-test = prev.plover-stenohid-test.overridePythonAttrs (old: {
-    nativeBuildInputs = [ setuptools-scm ];
-    dependencies = [
-      hidapi
-      pyudev
-    ];
+    # plover-hid with automatic reconnect is in plover now
+    meta.broken = true;
   });
 
   # plover-stenotype-extended

--- a/plover.nix
+++ b/plover.nix
@@ -16,7 +16,7 @@
   certifi,
   cmarkgfm,
   evdev,
-  hid,
+  hidapi,
   psutil,
   pyside6,
   pyserial,
@@ -36,6 +36,13 @@
   pyobjc-framework-Quartz,
 }:
 let
+  # python-hidraw does not use hidapi by default
+  # even though the documentation says that it should
+  hidapi-hidraw = hidapi.overrideAttrs (old: {
+    env = old.env // {
+      HIDAPI_WITH_HIDRAW = true;
+    };
+  });
   plover-stroke = buildPythonPackage {
     pname = "plover_stroke";
     version = "master";
@@ -88,7 +95,7 @@ buildPythonPackage {
 
   dependencies = [
     babel
-    hid
+    hidapi-hidraw
     pyside6
     xlib
     pyserial


### PR DESCRIPTION
Newer versions of plover use the hidapi pytyon
package instead of the hid python package.

The nix derivation needs an override due to
hidapi not defaulting to using raw hid on Linux,
even though the documentation says it should.