### PR TITLE
fix: build for Plover v5.2.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770181073,
-        "narHash": "sha256-ksTL7P9QC1WfZasNlaAdLOzqD8x5EPyods69YBqxSfk=",
+        "lastModified": 1770197578,
+        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf922a59c5c9998a6584645f7d0de689512e444c",
+        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "plover": {
       "flake": false,
       "locked": {
-        "lastModified": 1769926274,
-        "narHash": "sha256-aUWXow0GjG5U0l5WrI5qruT/KCVY9SUJkXnohxKIpPs=",
+        "lastModified": 1770363408,
+        "narHash": "sha256-5VlX3rdLBp6in2MNZpf69KDi5wqsmJcv+3klFz1MGFE=",
         "owner": "openstenoproject",
         "repo": "plover",
-        "rev": "edc316f25cfb5835946275bd9e1d8dd7dda38a30",
+        "rev": "a04f2c8d1a60c275a20b907b147c803932ed35bc",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     "plover2cat": {
       "flake": false,
       "locked": {
-        "lastModified": 1769923641,
-        "narHash": "sha256-O+slgZGB9QxMnrSKC+cBTyV6UGwunoZ88M2IHbbkfds=",
+        "lastModified": 1770344683,
+        "narHash": "sha256-CSydXof9n5zWL7rT2cI+a81N+fxYDOIF9FRgaEk0XFo=",
         "owner": "greenwyrt",
         "repo": "plover2CAT",
-        "rev": "09efb088e241d9f4cfd7faad6b9b53b28a4a5725",
+        "rev": "2f7028415b1eaffd3122b9947a9b929b8612bdf5",
         "type": "github"
       },
       "original": {

--- a/overrides.nix
+++ b/overrides.nix
@@ -103,6 +103,7 @@ final: prev: {
     postPatch = ''
       substituteInPlace "setup.cfg" --replace-fail "PySide6-Essentials" "PySide6"
       sed -i '/PySide6-Addons/d' 'setup.cfg'
+      substituteInPlace "pyproject.toml" --replace-fail "plover[gui_qt]>=5.0.0.dev2" "plover"
     '';
   };
 
@@ -134,6 +135,12 @@ final: prev: {
   # plover-clippy
   # plover-clippy-2
   # plover-clr-trans-state
+
+  plover-combo = prev.plover-combo.overridePythonAttrs (old: {
+    postPatch = ''
+      substituteInPlace "pyproject.toml" --replace-fail "plover[gui_qt]>=5.0.0.dev2" "plover"
+    '';
+  });
 
   # plover-comment
 

--- a/plover.nix
+++ b/plover.nix
@@ -155,13 +155,8 @@ buildPythonPackage {
     "plover_build_utils"
   ];
 
-  # PySide6-Essentials it not on nixpkgs. See: https://github.com/NixOS/nixpkgs/issues/277849
-  # In addition, plover requires xkbcommon<1.1, but nixpkgs has 1.5.1
+  # plover requires xkbcommon<1.1, but nixpkgs has 1.5.1
   postPatch = ''
-    substituteInPlace "pyproject.toml" --replace-fail "PySide6-Essentials" "PySide6"
-    substituteInPlace "reqs/setup.txt" --replace-fail "PySide6-Essentials" "PySide6"
-    substituteInPlace "reqs/dist_extra_gui_qt.txt" --replace-fail "PySide6-Essentials" "PySide6"
-    substituteInPlace "reqs/constraints.txt" --replace-fail "PySide6-Essentials" "PySide6"
     substituteInPlace "reqs/dist.txt" --replace-fail "xkbcommon<1.1;" "xkbcommon<=1.5.1;"
   '';
 


### PR DESCRIPTION
## Background

- Resolves https://github.com/opensteno/plover-flake/issues/275

## Changes

1. Run `nix flake update` on macOS
2. Remove `PySide6-Essentials` replacement for plover
3. Resolve some plugin build failures as follows:

```nix
      substituteInPlace "pyproject.toml" --replace-fail "plover[gui_qt]>=5.0.0.dev2" "plover"
```

> I don't know why this is needed though..

## Confirmed

- [x] Build on macOS
- [ ] Run each package on macOS
- [x] Build on Linux with CI
- [ ] Run each package on Linux

Let me merge this PR by myself for a quick fix.

## Offtopic

I found this [notification setting](https://github.com/settings/notifications), so the chance will be high that I can fix those CI failures:

<img width="463" height="158" alt="Screenshot 2026-02-06 at 18 43 40" src="https://github.com/user-attachments/assets/700087a7-8c9a-4e90-842b-4ee6e4edcb0f" />

