### PR TITLE
fix: mark `plover-touch-tablets` as broken

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -439,6 +439,10 @@ final: prev: {
     meta.broken = true;
   });
 
+  plover-touch-tablets = prev.plover-touch-tablets.overridePythonAttrs (old: {
+    meta.broken = true;
+  });
+
   plover-uinput = prev.plover-uinput.overridePythonAttrs (old: {
     dependencies = [
       evdev


### PR DESCRIPTION
## Background

See the [Garnix CI failure](https://github.com/opensteno/plover-flake/runs/63653778414).

```
error: build of '/nix/store/gn4p68f4iwmp11aiwn7qn0yi1qwvippy-python3.13-plover-touch-tablets-0.0.2.drv' on 'ssh-ng://nix-ssh@garnix5' failed: builder for '/nix/store/gn4p68f4iwmp11aiwn7qn0yi1qwvippy-python3.13-plover-touch-tablets-0.0.2.drv' failed with exit code 1;
       last 25 log lines:
       > adding 'plover_touch_tablets/client_config.py'
       > adding 'plover_touch_tablets/config.py'
       > adding 'plover_touch_tablets/debug.py'
       > adding 'plover_touch_tablets/encoding.py'
       > adding 'plover_touch_tablets/extended_engine.py'
       > adding 'plover_touch_tablets/extension.py'
       > adding 'plover_touch_tablets/get_logger.py'
       > adding 'plover_touch_tablets/lookup.py'
       > adding 'plover_touch_tablets/signal.py'
       > adding 'plover_touch_tablets/tool.py'
       > adding 'plover_touch_tablets-0.0.2.dist-info/METADATA'
       > adding 'plover_touch_tablets-0.0.2.dist-info/WHEEL'
       > adding 'plover_touch_tablets-0.0.2.dist-info/entry_points.txt'
       > adding 'plover_touch_tablets-0.0.2.dist-info/top_level.txt'
       > adding 'plover_touch_tablets-0.0.2.dist-info/RECORD'
       > removing build/bdist.linux-x86_64/wheel
       > Successfully built plover_touch_tablets-0.0.2-py3-none-any.whl
       > Finished creating a wheel...
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for plover_touch_tablets-0.0.2-py3-none-any.whl
       >   - websocket-client not installed
       >   - jsonpickle not installed
       >   - nacl-middleware not installed
       For full logs, run 'nix log /nix/store/gn4p68f4iwmp11aiwn7qn0yi1qwvippy-python3.13-plover-touch-tablets-0.0.2.drv'.
error: builder for '/nix/store/gn4p68f4iwmp11aiwn7qn0yi1qwvippy-python3.13-plover-touch-tablets-0.0.2.drv' failed with exit code 1
error: 1 dependencies of derivation '/nix/store/a1489xaxfgmsf6dw41byi40lrg536qwj-python3.13-plover-master.drv' failed to build
```

## Changes

I failed to build `plover-touch-tablets` with Nix, so let's mark it `broken` for now.

## Misc

- The bot PR was merged even if there's Garnix CI failure
- Garnix CI failures were not notified on GitHub
