### PR TITLE
ci: build `plover-full`

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -26,7 +26,7 @@ jobs:
           git add plugins.json && git commit -m 'update plugins.json' || true
       - name: Build flake
         run: |
-          nix build --show-trace
+          nix build plover-full --show-trace
       - name: Push to main
         run: |
           git push


### PR DESCRIPTION
## Background

Some broken plugin was not detected in `update-flake-lock`: https://github.com/opensteno/plover-flake/commit/17c1021b8f8e5536185261b551dc5cf13f54d08c.

## Changes

Build `plover-full` in the CI!

Edit: dnaq kindly fixed it to `.#plover-full`. Thank you.
