### PR TITLE
build: rename `nixfmt-rfc-style` to `nixfmt`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
       devShells = forEachSystem (pkgs: {
         default = pkgs.mkShell {
           packages = with pkgs; [
-            nixfmt-rfc-style
+            nixfmt
             statix
             nixd
           ];


### PR DESCRIPTION
Just resolve the warning:

```
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
```

I'm merging this trivial PR without review.