### PR TITLE
fix: `plover-full.withPlugins` with available plover plugins

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,16 +72,23 @@
 
         plover-full =
           let
-            plover' = plover.withPlugins (
-              ps: builtins.filter (x: x ? meta && !x.meta.broken) (builtins.attrValues ps)
+            availablePloverPlugins = builtins.filter (x: x ? meta && !x.meta.broken) (
+              builtins.attrValues self.ploverPlugins.${pkgs.stdenv.hostPlatform.system}
             );
+            plover' = pkgs.python3Packages.callPackage ./plover.nix { inherit inputs; };
+            plover'' = plover'.overridePythonAttrs (old: {
+              dependencies = old.dependencies ++ availablePloverPlugins;
+            });
             withPlugins =
               f: # f is a function such as (ps: with ps; [ plugin names ])
               plover'.overridePythonAttrs (old: {
-                dependencies = old.dependencies ++ (f self.ploverPlugins.${pkgs.stdenv.hostPlatform.system});
+                dependencies =
+                  old.dependencies
+                  ++ availablePloverPlugins
+                  ++ (f self.ploverPlugins.${pkgs.stdenv.hostPlatform.system});
               });
           in
-          plover' // { inherit withPlugins; };
+          plover'' // { inherit withPlugins; };
 
         update = pkgs.callPackage ./update.nix { inherit inputs; };
       });


### PR DESCRIPTION
## Background

- Resolves https://github.com/opensteno/plover-flake/issues/285

## Tests

- [x] `plover-full`
- [x] `plover-full.withPlugins`
  - [x] All of the available plugin registry plugins are there
  - [x] A user plugin works

## TODOs..

- [x] Update the comments in `#287`
- [ ] Ask for review
