### PR TITLE
feat: patch `plover-sound`

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -367,13 +367,23 @@ final: prev: {
     meta.broken = true;
   });
 
-  plover-sound = prev.plover-sound.overridePythonAttrs (old: {
+  plover-sound = prev.plover-sound.overridePythonAttrs (old: rec {
+    pname = "plover-sound";
+    version = "0.0.4";
+        src = fetchPypi rec {
+      inherit pname version;
+      sha256 = "sha256-ZVn54enmC8ouxMTRHeNVudHSZUpUsDCMpUEQQunVjS4=";
+    };
     dependencies = [
       pygame
       numpy
     ];
-    # ModuleNotFoundError: No module named 'PyQt5'
-    meta.broken = true;
+    postPatch = ''
+      substituteInPlace plover_sound/tool.py \
+        --replace-fail "from PyQt5" "from PySide6" \
+        --replace-fail "ICON = 'asset:plover_sound:icon.svg'" \
+          "ICON = os.path.join(os.path.dirname(__file__), 'icon.svg')"
+    '';
   });
 
   plover-spanish-mqd = prev.plover-spanish-mqd.overridePythonAttrs (old: {


### PR DESCRIPTION
## Background

(Indirect) user request

## Changes

Patch [`plover-sound`](https://github.com/RAOEUS/plover-sound) for now:

<img width="884" height="652" alt="plover-sound" src="https://github.com/user-attachments/assets/2ea6d50d-42b6-49cf-8fa5-a96b6153c6f8" />

## Tests

- [x] X11
- [ ] Wayland
- [x] macOS

## Misc

- We should send PRs to upstream plugin repositories
- We need a way to detect overridden plugin update on upstream
