### PR TITLE
ci: add `nix flake check` for formatting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "plover": {
       "flake": false,
       "locked": {
@@ -87,7 +103,8 @@
         "plover-stroke": "plover-stroke",
         "plover2cat": "plover2cat",
         "plover_plugins_registry": "plover_plugins_registry",
-        "rtf-tokenize": "rtf-tokenize"
+        "rtf-tokenize": "rtf-tokenize",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "rtf-tokenize": {
@@ -103,6 +120,24 @@
       "original": {
         "owner": "openstenoproject",
         "repo": "rtf_tokenize",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,9 @@
       url = "github:greenwyrt/plover2CAT";
       flake = false;
     };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+    };
   };
 
   outputs =
@@ -35,6 +38,9 @@
       systems = lib.systems.flakeExposed;
       pkgsFor = lib.genAttrs systems (system: import nixpkgs { inherit system; });
       forEachSystem = f: lib.genAttrs systems (system: f pkgsFor.${system});
+      treefmtEval = forEachSystem (
+        pkgs: inputs.treefmt-nix.lib.evalModule pkgs { programs.nixfmt.enable = true; }
+      );
     in
     {
       devShells = forEachSystem (pkgs: {
@@ -47,7 +53,13 @@
         };
       });
 
-      formatter = forEachSystem (pkgs: pkgs.nixfmt-tree);
+      formatter = forEachSystem (
+        pkgs: treefmtEval.${pkgs.stdenv.hostPlatform.system}.config.build.wrapper
+      );
+
+      checks = forEachSystem (pkgs: {
+        formatting = treefmtEval.${pkgs.stdenv.hostPlatform.system}.config.build.check self;
+      });
 
       ploverPlugins = forEachSystem (
         pkgs:

--- a/overrides.nix
+++ b/overrides.nix
@@ -370,7 +370,7 @@ final: prev: {
   plover-sound = prev.plover-sound.overridePythonAttrs (old: rec {
     pname = "plover-sound";
     version = "0.0.4";
-        src = fetchPypi rec {
+    src = fetchPypi rec {
       inherit pname version;
       sha256 = "sha256-ZVn54enmC8ouxMTRHeNVudHSZUpUsDCMpUEQQunVjS4=";
     };


### PR DESCRIPTION
## Background

My last PR contained format error (sorry), but Garnix CI didn't warn about that.

## Changes

Add `nix flake check` command for format check.

## Test

- [x] Demonstrate the format failure on CI
  <img width="520" height="53" alt="format-error" src="https://github.com/user-attachments/assets/f15afd13-61ee-43ad-96cd-67e811dbec4a" />
- [x] Fix the CI error
- [x] Pass CI and merge