### PR TITLE
build: remove plover version patch for `plover-spanish-mqd` version 3.0.0

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -391,9 +391,6 @@ final: prev: {
 
   plover-spanish-mqd = prev.plover-spanish-mqd.overridePythonAttrs (old: {
     dependencies = [ final.plover-python-dictionary ];
-    postPatch = ''
-      substituteInPlace setup.cfg --replace-fail 'plover~=4.0.0.dev10' plover
-    '';
   });
 
   plover-spanish-system-eo-variant = prev.plover-spanish-system-eo-variant.overridePythonAttrs (old: {

--- a/plugins.json
+++ b/plugins.json
@@ -469,9 +469,9 @@
   },
   {
     "name": "plover-spanish-mqd",
-    "filename": "plover_spanish_mqd-2.1.7.tar.gz",
-    "version": "2.1.7",
-    "sha256": "397b957656c266fd2338f2814dfa09a9733a289996888e5a26f9ee6972caa0dd"
+    "filename": "plover_spanish_mqd-3.0.0.tar.gz",
+    "version": "3.0.0",
+    "sha256": "9276f26460a8d1b91dcff4a13c5d7c93d223d74835152bf5ef09b17442c93388"
   },
   {
     "name": "plover-spanish-system-eo-variant",


### PR DESCRIPTION
## Background

[3.0.0 release](https://github.com/nvdaes/plover_spanish_mqd/blob/main/CHANGELOG.md#300---2026-05-18)

## Changes

- Update the plugin
- Remove the Plover version replacement