### PR TITLE
ci: pass `zizmor`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -4,14 +4,20 @@ on:
   schedule:
     - cron: '30 3 * * *'
 
+permissions: {}
+
 jobs:
   lockfile:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

Pass the lint by [`zizmor`](https://github.com/zizmorcore/zizmor). Almost no effect for security, it's just for fun.
