### PR TITLE
ci: grant permission for `git push` along with `persist-credentials: false`

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -34,5 +34,8 @@ jobs:
         run: |
           nix build .#plover-full --show-trace
       - name: Push to main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          gh auth setup-git
           git push


### PR DESCRIPTION
## Background

- [CI failure](https://github.com/opensteno/plover-flake/actions/runs/26623365531) due to my last PR: https://github.com/opensteno/plover-flake/pull/295. Sorry..

## Changes

Switch to `gh auth setup-git` + `GH_TOKEN` per step. Maybe this is the common method..?
