### PR TITLE
build: plover 5.4.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     "plover": {
       "flake": false,
       "locked": {
-        "lastModified": 1777008591,
-        "narHash": "sha256-fb4EJ4REj8GW8+Z74oFiikgM/5yXgdon6I/NZYlZYLI=",
+        "lastModified": 1783663485,
+        "narHash": "sha256-qaEuzPVqh+e3qq778VdUaRufGzOx9HyUnygIbA0+6kw=",
         "owner": "openstenoproject",
         "repo": "plover",
-        "rev": "6b7a014100eca137e5e82961bb030156b114281a",
+        "rev": "8b0b2b03c6a7f3ca5f3ff9def7850fdf7e7d495e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,51 @@
     let
       inherit (nixpkgs) lib;
       systems = lib.systems.flakeExposed;
-      pkgsFor = lib.genAttrs systems (system: import nixpkgs { inherit system; });
+
+      # [HACK]
+      # Override cctools `ld` with LLVM's `lld` to avoid Qt 6.11 modules with naive Darwin plugins such as WebKit.
+      # We patch `python.pkgs.qt6` rather than `pkgs.qt6`, because `overrideScope` on the latter drops its `.override`,
+      # which `python-packages.nix` calls.
+      qtLldDarwinOverlay =
+        final: prev:
+        lib.optionalAttrs prev.stdenv.hostPlatform.isDarwin {
+          pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+            (
+              pyFinal: pyPrev:
+              let
+                withLld =
+                  drv:
+                  drv.overrideAttrs (old: {
+                    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.llvmPackages.lld ];
+                    env = (old.env or { }) // {
+                      NIX_CFLAGS_LINK = "-fuse-ld=lld";
+                    };
+                  });
+              in
+              {
+                pyside6 = withLld pyPrev.pyside6;
+                qt6 = pyPrev.qt6.overrideScope (
+                  _qtFinal: qtPrev:
+                  lib.genAttrs [
+                    "qtwebview"
+                    "qtspeech"
+                    "qtconnectivity"
+                    "qtpositioning"
+                    "qtlocation"
+                  ] (name: withLld qtPrev.${name})
+                );
+              }
+            )
+          ];
+        };
+
+      pkgsFor = lib.genAttrs systems (
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ qtLldDarwinOverlay ];
+        }
+      );
       forEachSystem = f: lib.genAttrs systems (system: f pkgsFor.${system});
       treefmtEval = forEachSystem (
         pkgs: inputs.treefmt-nix.lib.evalModule pkgs { programs.nixfmt.enable = true; }

--- a/overrides.nix
+++ b/overrides.nix
@@ -385,6 +385,12 @@ final: prev: {
         --replace-fail "from PyQt5" "from PySide6" \
         --replace-fail "ICON = 'asset:plover_sound:icon.svg'" \
           "ICON = os.path.join(os.path.dirname(__file__), 'icon.svg')"
+      # Prefer `asset:` URI and do not preserve absolute path to `/nix/store`
+      substituteInPlace plover_sound/extension.py \
+        --replace-fail "   default_sample_path = resource_filename(default_sample_path)" \
+          "   pass" \
+        --replace-fail "raise Exception(\"Couldn't find audio sample file\")" \
+          "self.sample_path = default_sample_path"
     '';
   });
 

--- a/overrides.nix
+++ b/overrides.nix
@@ -30,7 +30,7 @@
   plover,
   prompt-toolkit,
   pyfiglet,
-  pygame,
+  pygame-ce,
   pypandoc,
   pyparsing,
   pysdl2,
@@ -375,10 +375,11 @@ final: prev: {
       sha256 = "sha256-ZVn54enmC8ouxMTRHeNVudHSZUpUsDCMpUEQQunVjS4=";
     };
     dependencies = [
-      pygame
+      pygame-ce
       numpy
     ];
     postPatch = ''
+      substituteInPlace setup.cfg --replace-fail 'pygame' 'pygame-ce'
       substituteInPlace plover_sound/tool.py \
         --replace-fail "from PyQt5" "from PySide6" \
         --replace-fail "ICON = 'asset:plover_sound:icon.svg'" \

--- a/overrides.nix
+++ b/overrides.nix
@@ -219,6 +219,7 @@ final: prev: {
     in
     prev.plover-emoji.overridePythonAttrs (old: {
       dependencies = [
+        # pkg_resources is injected via `plover.nix`
         simplefuzzyset
       ];
     });

--- a/overrides.nix
+++ b/overrides.nix
@@ -389,6 +389,9 @@ final: prev: {
 
   plover-spanish-mqd = prev.plover-spanish-mqd.overridePythonAttrs (old: {
     dependencies = [ final.plover-python-dictionary ];
+    postPatch = ''
+      substituteInPlace pyproject.toml --replace-fail 'plover~=5.3.0' plover
+    '';
   });
 
   plover-spanish-system-eo-variant = prev.plover-spanish-system-eo-variant.overridePythonAttrs (old: {

--- a/overrides.nix
+++ b/overrides.nix
@@ -338,14 +338,7 @@ final: prev: {
   # plover-portuguese
   # plover-python-dictionary
   # plover-q-and-a
-
-  plover-regenpfeifer = prev.plover-regenpfeifer.overridePythonAttrs (old: {
-    dependencies = [
-      pygame
-      numpy
-    ];
-  });
-
+  # plover-regenpfeifer
   # plover-retro-case
   # plover-retro-everything
   # plover-retro-quotes

--- a/plover.nix
+++ b/plover.nix
@@ -1,5 +1,6 @@
 {
   buildPythonPackage,
+  fetchPypi,
   inputs,
   lib,
   pkgs,
@@ -17,6 +18,8 @@
   cmarkgfm,
   evdev,
   hidapi,
+  jaraco-text,
+  platformdirs,
   psutil,
   pyside6,
   pyserial,
@@ -37,6 +40,30 @@
   pyobjc-framework-Quartz,
 }:
 let
+  # For stale packages:
+  pkg-resources = buildPythonPackage {
+    pname = "pkg-resources";
+    version = "80.9.0";
+    format = "other";
+    src = fetchPypi {
+      pname = "setuptools";
+      version = "80.9.0";
+      hash = "sha256-82tHQC7N52jb+vxG6OQge0NgxlTx87uER18KKGKPsZw=";
+    };
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/${pkgs.python3.sitePackages}"
+      cp -r pkg_resources "$out/${pkgs.python3.sitePackages}/"
+      runHook postInstall
+    '';
+    # setuptools 80.9.0 de-vendored pkg_resources; these are its real runtime imports.
+    dependencies = [
+      packaging
+      jaraco-text
+      platformdirs
+    ];
+  };
+
   # python-hidraw does not use hidapi by default
   # even though the documentation says that it should
   hidapi-hidraw = hidapi.overrideAttrs (old: {
@@ -103,6 +130,7 @@ buildPythonPackage {
     appdirs
     wcwidth
     setuptools
+    pkg-resources # for stale packages (TODO: delete it)
     certifi
     packaging
     pkginfo


### PR DESCRIPTION
Update for [Plover 5.4.0](https://github.com/opensteno/plover/releases/tag/v5.4.0).

- Force LLVM's `lld` to Qt on macOS. It may be an upstream issue.
- Handle Python version bump from `3.13` to `3.14`
  - `pygame` is changed from `pygame-original` to `pygame-ce`, the [community edition](https://pypi.org/project/pygame-ce/) that's actively maintained for Python 3.14 and later.
  - `pkg_resources` is gone in Python 3.14, so inject it explicitly for stale packages.
- Fix `plover-sound` with audio file missing errors. It writes the absolute asset file path in `plover_sound_conf.py`, but those files in `/nix/store` can be removed. Patch it to write `asset:plover_sound:<name>.mp3` instead.

Lapwing and `plover_sound` worked on:

- [x] arm64 macOS
- [x] x86_64 NixOS with X11 (i3)
- [x] x86_64 NixOS with Wayland (Sway)