### PR TITLE
build: update `flake.lock` and bypass `pythonMetadataCheckHook`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     "plover": {
       "flake": false,
       "locked": {
-        "lastModified": 1783854653,
-        "narHash": "sha256-LSX+ko0nL7DXjzKjbpeGl/SmreQB/FscBeZEKysgvss=",
+        "lastModified": 1784839372,
+        "narHash": "sha256-zA3DsOZ5ry9Wjom1ksOlFekH/KEY2fZkwINuOxPrbKA=",
         "owner": "openstenoproject",
         "repo": "plover",
-        "rev": "81cef57401111a40be23673e31a4e45665a28ef3",
+        "rev": "21005813140c50f9541994a8d0433f3ee447e561",
         "type": "github"
       },
       "original": {

--- a/overrides.nix
+++ b/overrides.nix
@@ -86,7 +86,9 @@ let
   };
 in
 final: prev: {
-  # alleycat-link
+  alleycat-link = prev.alleycat-link.overridePythonAttrs (old: {
+    version = "0-unstable-main"; # Bypass `pythonMetadataCheckHook`
+  });
 
   plover-pinchord = prev.plover-pinchord.overridePythonAttrs (old: {
     dependencies = [ final.plover-python-dictionary ];
@@ -94,7 +96,7 @@ final: prev: {
 
   plover2cat = buildPythonPackage {
     pname = "plover2cat";
-    version = "master";
+    version = "0-unstable-main"; # Bypass `pythonMetadataCheckHook`
     src = inputs.plover2cat;
     pyproject = true;
     build-system = [ setuptools ];

--- a/plover.nix
+++ b/plover.nix
@@ -73,14 +73,14 @@ let
   });
   plover-stroke = buildPythonPackage {
     pname = "plover_stroke";
-    version = "master";
+    version = "0-unstable-main"; # bypass `pythonMetadataCheckHook`
     src = inputs.plover-stroke;
     pyproject = true;
     build-system = [ setuptools ];
   };
   rtf-tokenize = buildPythonPackage {
     pname = "rtf_tokenize";
-    version = "master";
+    version = "0-unstable-main"; # bypass `pythonMetadataCheckHook`
     src = inputs.rtf-tokenize;
     pyproject = true;
     build-system = [ setuptools ];
@@ -98,7 +98,7 @@ let
 in
 buildPythonPackage {
   pname = "plover";
-  version = "master";
+  version = "0-unstable-main"; # bypass `pythonMetadataCheckHook`
   src = inputs.plover;
   pyproject = true;
   build-system = [ setuptools ];


### PR DESCRIPTION
Today, [`pythonMetadataCheckHook`](https://github.com/NixOS/nixpkgs/blob/a76040f2dfc63651fbe557ea87cdd68aef8dc1c5/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh) is forced, and the version check must be bypassed.

- `master` is rejected
- `alleycat-link` lacks `_version.txt` in the repo

Let's bypass these errors with `0-unstable-main` version literal. (Not so good?)