### PR TITLE
patch: use stdenv.hostPlatform.is* instead of deprecated stdenv.is*

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -131,10 +131,10 @@ in
         {
           home.packages = [ cfg.package ];
         }
-        (lib.mkIf (cfg.settings != null && pkgs.stdenvNoCC.isLinux) {
+        (lib.mkIf (cfg.settings != null && pkgs.stdenvNoCC.hostPlatform.isLinux) {
           home.file.".config/plover/plover.cfg".source = configFile;
         })
-        (lib.mkIf (cfg.settings != null && pkgs.stdenvNoCC.isDarwin) {
+        (lib.mkIf (cfg.settings != null && pkgs.stdenvNoCC.hostPlatform.isDarwin) {
           home.file."Library/Application Support/plover/plover.cfg".source = configFile;
         })
       ]

--- a/overrides.nix
+++ b/overrides.nix
@@ -305,7 +305,7 @@ in
     dependencies = [
       pystray
     ];
-    meta.broken = stdenvNoCC.isDarwin;
+    meta.broken = stdenvNoCC.hostPlatform.isDarwin;
   };
 
   # hiadpi
@@ -324,7 +324,7 @@ in
       substituteInPlace setup.cfg --replace-fail 'xkbcommon<1.1' xkbcommon
     '';
 
-    meta.broken = stdenvNoCC.isDarwin;
+    meta.broken = stdenvNoCC.hostPlatform.isDarwin;
   };
 
   # ImportError: cannot import name 'Test' from 'plover_build_utils.setup'

--- a/plover.nix
+++ b/plover.nix
@@ -111,7 +111,7 @@ buildPythonPackage {
   buildInputs = [
     qt6.qtsvg # required for rendering icons
   ]
-  ++ lib.optionals pkgs.stdenv.isLinux [
+  ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
     qt6.qtwayland
   ];
 
@@ -144,10 +144,10 @@ buildPythonPackage {
     rtf-tokenize
     xkbcommon
   ]
-  ++ lib.optionals stdenvNoCC.isLinux [
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [
     evdev
   ]
-  ++ lib.optionals stdenvNoCC.isDarwin [
+  ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
     appnope
     pyobjc-core
     pyobjc-framework-Cocoa


### PR DESCRIPTION
recent plover-flake builds from home-manage module emits following
warnings:

```bash
evaluation warning: stdenv.isLinux is deprecated, use stdenv.hostPlatform.isLinux instead
```

This is cause by a recent nixpkgs update
https://github.com/NixOS/nixpkgs/pull/518407, which deprecates all
stdenv.is* use.

This PR sweeps and replaces old `stdenv.is*` use with the recommended
form `stdenv.hostPlatform.is*`
